### PR TITLE
Begin working toward a rustc --debug -g compilation, w/ file/line data

### DIFF
--- a/conductor/rust/install/default.nix
+++ b/conductor/rust/install/default.nix
@@ -4,7 +4,7 @@ let
 
   script = pkgs.writeShellScriptBin name
   ''
-  cargo build -p holochain --release && cargo install -f --path conductor
+  cargo build -p holochain && cargo install -f --path conductor
   '';
 in
 {


### PR DESCRIPTION
During the alpha phase of holochain-rust, we need debug info (file and line number) for panic! backtraces (with RUST_BACKTRACE=1).

This doesn't appear to actually link the holochain-rust/target/debug/holochain executable into .cargo/bin/, though, so this pull is incomplete...

However: it is *critical* (as in -- it is a *showstopper*) to experience a `panic!` due to .unwrap(), etc., without this information!  So, please consider this an important feature request.  Building it more cleanly into holonix (eg. as a config.nix option) would be nice.  But, the results (either `debug/` or `release/<executable>`) needs to be deployed so that it becomes the default `.cargo/bin/<executable>`.