### PR TITLE
run nix-shell quick start tests against local

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,13 +22,13 @@ jobs:
        curl https://nixos.org/nix/install | sh
        . /Users/distiller/.nix-profile/etc/profile.d/nix.sh
        nix-shell --run hn-test
-       
+
  quick-start:
   macos:
    xcode: "10.2.0"
   steps:
    - checkout
-   - run: 
+   - run:
       # https://developer.holochain.org/start.html
       name: Run through quick start
       command: |
@@ -36,33 +36,33 @@ jobs:
        # The official instructions are here.
        # Open a command line terminal and run:
        curl https://nixos.org/nix/install | sh
-       
+
        # Follow any additional instructions at the end of the installation process.
        # It should be a smooth process.
        # Check the instructions linked above for any troubleshooting.
        . /Users/distiller/.nix-profile/etc/profile.d/nix.sh
-       
+
        # Nix is configured by default.nix files.
        # These set all dependencies and variables added to your terminal.
        # There is a master default.nix file updated from time to time.
        # You can extend this or use it directly from https://holochain.love.
        # Opening a shell from holochain.love downloads updates automatically.
        # To enter a nix shell environment open a new terminal window and run:
-       nix-shell https://holochain.love --run echo
-       
+       nix-shell --run echo
+
        # In the nix shell you can access Holochain dev tools:
        # - hc: A general purpose app development toolkit.
        # - holochain: Runs holochain apps.
        # You can see both are installed by checking their versions.
        # Inside a nix shell run:
-       nix-shell https://holochain.love --run 'hc --version'
-       nix-shell https://holochain.love --run 'holochain --version'
-       
+       nix-shell --run 'hc --version'
+       nix-shell --run 'holochain --version'
+
        # Nix cleans up everything it adds when closed.
        # You need to re-enter the shell each time you want to work.
        # To close nix shell run this inside the shell:
        # exit
-       
+
        # nix-env can be used to permanently install holochain tools.
        # This means that hc and holochain can be run at any time.
        # nix-env can also uninstall tools it installs.
@@ -70,23 +70,23 @@ jobs:
        # Use nix-shell if you want the latest releases.
        # Use nix-env if you want a single copy of the tools everywhere.
        # To install holochain and hc with nix-env run (on one line):
-       nix-env -f https://holochain.love -iA holochain.holochain holochain.hc
-       
+       nix-env -f `pwd` -iA holochain.holochain holochain.hc
+
        # Test this by running the following _outside_ nix-shell:
        hc --version
        holochain --version
-       
+
        # To uninstall holochain and hc with nix-env run:
        nix-env -e holochain hc
-       
+
        # The hc tool can generate the basics of a new Holochain app.
        # hc is available in nix-shell or can be installed by nix-env.
-       
+
        # The command to generate a new app is "hc init ".
        # Let's create a new app called "my_first_app".
        # To do this with hc run:
-       nix-shell https://holochain.love --run 'hc init my_first_app'
-       
+       nix-shell --run 'hc init my_first_app'
+
        # The basic structure of a Holochain project is now in the "my_first_app" folder.
        # Explore it in a file browser or text editor.
        # Once you have a feel for what was created try generating a "zome".
@@ -94,19 +94,19 @@ jobs:
        # First make sure your terminal is working from the "my_first_app" folder.
        # Run the following to "change directory" to the app:
        cd my_first_app
-       
+
        # Next run:
-       nix-shell https://holochain.love --run 'hc generate zomes/my_zome'
-       
+       nix-shell --run 'hc generate zomes/my_zome'
+
        # This will add real Rust code into the "zomes/my_zome" sub folder.
        # You can open the generated code in a text editor and start building!
        # The generated zomes come with a simple automated test suite.
        # The tests can be found in "my_first_app/test/index.js".
        # The tests can be run with the test command:
-       nix-shell https://holochain.love --run 'hc test'
-       
+       nix-shell --run 'hc test'
+
        # To learn more about the hc tool, run the help command:
-       nix-shell https://holochain.love --run 'hc help'
+       nix-shell --run 'hc help'
 
 workflows:
  version: 2


### PR DESCRIPTION
this removes `https://holochain.love` references from the quick start

this is because the quick start testing should be against what _will be_ launched not what _is currently_ live