### PR TITLE
put the v in the release tag

### DIFF
--- a/nix-shell/default.nix
+++ b/nix-shell/default.nix
@@ -30,6 +30,9 @@
  NUM_JOBS = rust.compile.jobs;
  RUST_BACKTRACE = rust.backtrace;
 
+ RELEASE_VERSION = release.config.release.version.current;
+ RELEASE_TAG = release.config.release.tag;
+
  OPENSSL_STATIC = openssl.static;
 
  shellHook = ''

--- a/release/default.nix
+++ b/release/default.nix
@@ -4,7 +4,7 @@ let
  release-config = config // {
   release = config.release // {
    # release tag name
-   tag = config.release.version.current;
+   tag = "v${config.release.version.current}";
 
    # name of the branch used to facilitate release
    branch = "release-${config.release.version.current}";
@@ -41,4 +41,6 @@ in
   config = release-config;
  }).buildInputs
  ;
+
+ config = release-config;
 }

--- a/test/nix-shell.bats
+++ b/test/nix-shell.bats
@@ -9,3 +9,8 @@
 @test "rust backtrace is set in shell" {
   [ "$RUST_BACKTRACE" == "1" ]
 }
+
+@test "default release tag is set" {
+ [ "$RELEASE_VERSION" == "_._._" ]
+ [ "$RELEASE_TAG" == "v_._._" ]
+}


### PR DESCRIPTION
after much discussion the `v` is back in the release tag

exposes two environment variables inside nix shell `RELEASE_VERSION` and `RELEASE_TAG`

tests the new environment variables against default setup