### PR TITLE
Fix hc-rust-manifest-list-unpinned

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -16,4 +16,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- `hc-rust-manifest-list-unpinned` won't traverse `.cargo/` anymore which resulted in false positives [PR#58](https://github.com/holochain/holonix/pull/58)
+
 ### Security

--- a/rust/manifest/list-unpinned/default.nix
+++ b/rust/manifest/list-unpinned/default.nix
@@ -4,7 +4,7 @@ let
 
   script = pkgs.writeShellScriptBin name
   ''
-  find . -type f \( -name "Cargo.toml" -or -name "Cargo.template.toml" \) | xargs cat | grep -Ev '=[0-9]+\.[0-9]+\.[0-9]+' | grep -E '[0-9]+' | grep -Ev '(version|edition|codegen-units|{ git = ".*", rev = "\w+" })' | cat
+  find . -type f \( -name "Cargo.toml" -or -name "Cargo.template.toml" \) -not -path "./.cargo/*" | xargs cat | grep -Ev '=[0-9]+\.[0-9]+\.[0-9]+' | grep -E '[0-9]+' | grep -Ev '(version|edition|codegen-units|{ git = ".*", rev = "\w+" })' | cat
   '';
 in
 {


### PR DESCRIPTION
It was showing unpinned dependencies of dependencies inside `.cargo/`.
This excludes `.cargo` from the check for unpinned dependencies.