### PR TITLE
Add darwin derivation to default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -61,4 +61,5 @@ in
 
  # expose other things
  rust = rust;
+ darwin = darwin;
 }


### PR DESCRIPTION
In order to have faster build for only Rust dependent project, this PR proposes to  expose the **darwin** derivation.