### PR TITLE
Modify clippy configuration to fail only if the change could be fixed automatically

### DIFF
--- a/rust/clippy/default.nix
+++ b/rust/clippy/default.nix
@@ -4,9 +4,10 @@ let
 
  script = pkgs.writeShellScriptBin name
  ''
- echo "submitting to the wrath of clippy"
- cargo fix -Z unstable-options --clippy --target-dir "$HC_TARGET_PREFIX"/target/clippy
- git diff-files --quiet
+ cargo clippy --target-dir "$HC_TARGET_PREFIX"/target/clippy -- \
+ -A clippy::nursery -D clippy::style -A clippy::cargo \
+ -A clippy::pedantic -A clippy::restriction \
+ -D clippy::complexity -D clippy::perf -D clippy::correctness
  '';
 in
 {

--- a/rust/clippy/default.nix
+++ b/rust/clippy/default.nix
@@ -5,10 +5,8 @@ let
  script = pkgs.writeShellScriptBin name
  ''
  echo "submitting to the wrath of clippy"
- cargo clippy --target-dir "$HC_TARGET_PREFIX"/target/clippy -- \
- -A clippy::nursery -A clippy::style -A clippy::cargo \
- -A clippy::pedantic -A clippy::restriction \
- -D clippy::complexity -D clippy::perf -D clippy::correctness
+ cargo fix -Z unstable-options --clippy --target-dir "$HC_TARGET_PREFIX"/target/clippy
+ git diff-files --quiet
  '';
 in
 {


### PR DESCRIPTION
In addition, enable style lints. As a result, our allows our now the same as the default, so the options to allow and deny certain lints are unnecessary and have been removed.

For more context, see https://github.com/holochain/holochain-rust/pull/1800#issuecomment-567146887

cc @thedavidmeister