### PR TITLE
Add kcov and tools

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 {{ version-heading }}
 
 ### Added
+- kcov (if linux - technically should work on macOs, but something is broken with the nix package)
+- cargo-make (build scripting support - makes it easier to run kcov)
+- curl (needed for publishing coverage results to codecov.io)
 
 ### Changed
 

--- a/rust/default.nix
+++ b/rust/default.nix
@@ -14,7 +14,10 @@ rust //
   pkgs.openssl
   pkgs.pkgconfig
   pkgs.carnix
+  pkgs.cargo-make
+  pkgs.curl
  ]
+ ++ (if pkgs.stdenv.isLinux then [ pkgs.kcov ] else [])
  ++ (pkgs.callPackage ./clippy { }).buildInputs
  ++ (pkgs.callPackage ./fmt { }).buildInputs
  ++ (pkgs.callPackage ./manifest { }).buildInputs

--- a/test/nix-env.sh
+++ b/test/nix-env.sh
@@ -44,7 +44,7 @@ teardown () {
  echo '# sim2h_server should be installed now' >&3
  [ -x "$( command -v sim2h_server )" ]
 
- version="$( sim2h_server -V )"
+ version="$( sim2h_server -V 2>/dev/null )"
  echo "# smoke test sim2h_server version result: $version" >&3
  [[ "$version" == "sim2h_server 0.0."* ]]
 

--- a/test/nix-env.sh
+++ b/test/nix-env.sh
@@ -46,7 +46,7 @@ teardown () {
 
  version="$( sim2h_server -V 2>/dev/null )"
  echo "# smoke test sim2h_server version result: $version" >&3
- [[ "$version" == "sim2h_server 0.0."* ]]
+ [[ "$version" == "sim2h-server 0.0."* ]]
 
  echo '# uninstall sim2h_server' >&3
  nix-env -e sim2h_server


### PR DESCRIPTION
### Added
- kcov (if linux - technically should work on macOs, but something is broken with the nix package)
- cargo-make (build scripting support - makes it easier to run kcov)
- curl (needed for publishing coverage results to codecov.io)