### PR TITLE
[SPIKE - no merge] Deny missing docs

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 ### Changed
+- add `-D missing_docs` to require rust docs on public items
 
 ### Deprecated
 

--- a/rust/config.nix
+++ b/rust/config.nix
@@ -31,7 +31,10 @@ let
     compile = {
 
       # @see https://github.com/rust-unofficial/patterns/blob/master/anti_patterns/deny-warnings.md
-      deny = "warnings";
+      deny = (builtins.foldl' (x: y: x + " -D " + y) "" [
+        "warnings"
+        "missing_docs"
+      ]);
 
       lto = "thinlto";
 
@@ -80,7 +83,7 @@ let
 
     compile = base.compile // {
       # @see https://llogiq.github.io/2017/06/01/perf-pitfalls.html
-      flags ="-D ${base.compile.deny} -Z external-macro-backtrace -Z ${base.compile.lto} -C codegen-units=${base.compile.codegen-units} -C opt-level=${base.compile.optimization-level} -C debuginfo=${base.compile.debug-level}";
+      flags ="${base.compile.deny} -Z external-macro-backtrace -Z ${base.compile.lto} -C codegen-units=${base.compile.codegen-units} -C opt-level=${base.compile.optimization-level} -C debuginfo=${base.compile.debug-level}";
     };
 
     test = {


### PR DESCRIPTION
Don't merge this yet, as it'll break everything that doesn't have docs on it.

- add `-D missing_docs` to require rust docs on public items