### PR TITLE
Fix holonix docker deploy

### DIFF
--- a/docker/build
+++ b/docker/build
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 owner=holochain
-repo=holochain-rust
+repo=holonix
 box=${1:-sim2h_server}
 branch=${2:-$( git rev-parse --abbrev-ref HEAD )}
 tag="$owner/$repo:$box.$branch"

--- a/docker/push
+++ b/docker/push
@@ -11,7 +11,8 @@ tag="$owner/$repo:$box.$branch"
 
 docker push "holochain/holonix:$box.$branch"
 
-while read region; do
- docker tag $tag "024992937548.dkr.ecr.$region.amazonaws.com/$tag"
- docker push "024992937548.dkr.ecr.$region.amazonaws.com/$tag"
-done < $dir/aws-regions.txt
+# We don't need this anymore
+#while read region; do
+# docker tag $tag "024992937548.dkr.ecr.$region.amazonaws.com/$tag"
+# docker push "024992937548.dkr.ecr.$region.amazonaws.com/$tag"
+#done < $dir/aws-regions.txt

--- a/docker/push
+++ b/docker/push
@@ -4,12 +4,12 @@ set -euxo pipefail
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 owner=holochain
-repo=holochain-rust
+repo=holonix
 box=${1:-sim2h_server}
 branch=${2:-$( git rev-parse --abbrev-ref HEAD )}
 tag="$owner/$repo:$box.$branch"
 
-docker push "holochain/holochain-rust:$box.$branch"
+docker push "holochain/holonix:$box.$branch"
 
 while read region; do
  docker tag $tag "024992937548.dkr.ecr.$region.amazonaws.com/$tag"


### PR DESCRIPTION
- docker build and push on hn-release-cut was overwriting holochain-rust docker images by mistake
- disable pushing to aws as we don't need it