### PR TITLE
nix-shell: use bash from nixpkgs explicitly

### DIFF
--- a/nix-shell/default.nix
+++ b/nix-shell/default.nix
@@ -68,6 +68,7 @@
  export CARGO_CACHE_RUSTC_INFO=1
  export PATH="$CARGO_INSTALL_ROOT/bin:$PATH"
  export NIX_LDFLAGS="${darwin.ld-flags}$NIX_LDFLAGS"
+ export NIX_BUILD_SHELL=${pkgs.bashInteractive}/bin/bash
 
  # https://github.com/holochain/holonix/issues/12
  export TMP=$( mktemp -p /tmp -d )


### PR DESCRIPTION
An attempt to fix https://github.com/holochain/holonix/issues/141 by explicitly forcing ```nix-shell``` using bash from nixpkgs rather than from the system path.