### PR TITLE
bump rust to nightly 2020-04-06

### DIFF
--- a/rust/config.nix
+++ b/rust/config.nix
@@ -8,7 +8,7 @@ let
     # https://hackmd.io/ShgxFyDVR52gnqK7oQsuiQ
     channel = {
       name = "nightly";
-      date = "2019-11-16";
+      date = "2020-04-06";
     };
 
     # the target used by rust when compiling wasm
@@ -80,7 +80,7 @@ let
 
     compile = base.compile // {
       # @see https://llogiq.github.io/2017/06/01/perf-pitfalls.html
-      flags ="-D ${base.compile.deny} -Z external-macro-backtrace -Z ${base.compile.lto} -C codegen-units=${base.compile.codegen-units} -C opt-level=${base.compile.optimization-level} -C debuginfo=${base.compile.debug-level}";
+      flags ="-D ${base.compile.deny} -Z macro-backtrace -Z ${base.compile.lto} -C codegen-units=${base.compile.codegen-units} -C opt-level=${base.compile.optimization-level} -C debuginfo=${base.compile.debug-level}";
     };
 
     test = {

--- a/test/clippy.bats
+++ b/test/clippy.bats
@@ -5,7 +5,7 @@
 @test "clippy version" {
  result="$( cargo clippy --version )"
  echo $result
- [[ "$result" == *2019-11-14* ]]
+ [[ "$result" == *2020-04-03* ]]
 }
 
 @test "clippy smoke test" {

--- a/test/rust.bats
+++ b/test/rust.bats
@@ -5,7 +5,7 @@
 @test "rustc version" {
  result="$( rustc --version )"
  echo $result
- [[ "$result" == *2019-11-15* ]]
+ [[ "$result" == *2020-04-05* ]]
 }
 
 # the rust fmt version should be roughly the rustc version
@@ -13,12 +13,12 @@
 @test "fmt version" {
  result="$( cargo fmt --version )"
  echo $result
- [[ "$result" == *2019-10-07* ]]
+ [[ "$result" == *2020-03-31* ]]
 }
 
 # RUSTFLAGS should be set correctly
 @test "RUSTFLAGS value" {
  result="$( echo $RUSTFLAGS )"
  echo $result
- [[ "$result" == '-D warnings -Z external-macro-backtrace -Z thinlto -C codegen-units=10 -C opt-level=z -C debuginfo=2' ]]
+ [[ "$result" == '-D warnings -Z macro-backtrace -Z thinlto -C codegen-units=10 -C opt-level=z -C debuginfo=2' ]]
 }


### PR DESCRIPTION
Notable change is that the macro ```external-macro-backtrace``` has been renamed to ```macro-backtrace``` back in February.