### PR TITLE
switch to stable rust and adjust bump rust nightly to 2020-04-06

### DIFF
--- a/rust/config.nix
+++ b/rust/config.nix
@@ -1,14 +1,15 @@
 let
   base = {
 
-    # our rust nightly version
-    # find a version that hits clippy and fmt support
+    # our rust version is by default stable
+    # to use rust nightly define the date by
+    # finding a version that hits clippy and fmt support
     # https://rust-lang.github.io/rustup-components-history/
     # read more about version management
     # https://hackmd.io/ShgxFyDVR52gnqK7oQsuiQ
-    channel = {
-      name = "nightly";
-      date = "2019-11-16";
+    channel = rec {
+      name = "stable";
+      date = (if (name != "stable") then "2020-04-06" else null);
     };
 
     # the target used by rust when compiling wasm
@@ -75,12 +76,15 @@ let
   derived = {
 
     channel = base.channel // {
-      version = "${base.channel.name}-${base.channel.date}";
+      version = if base.channel.date != null then "${base.channel.name}-${base.channel.date}" else "${base.channel.name}";
     };
 
     compile = base.compile // {
       # @see https://llogiq.github.io/2017/06/01/perf-pitfalls.html
-      flags ="-D ${base.compile.deny} -Z external-macro-backtrace -Z ${base.compile.lto} -C codegen-units=${base.compile.codegen-units} -C opt-level=${base.compile.optimization-level} -C debuginfo=${base.compile.debug-level}";
+      flags = if base.channel.date != null then
+                "-D ${base.compile.deny} -Z external-macro-backtrace -Z ${base.compile.lto} -C codegen-units=${base.compile.codegen-units} -C opt-level=${base.compile.optimization-level} -C debuginfo=${base.compile.debug-level}"
+              else
+                "-D ${base.compile.deny} -C codegen-units=${base.compile.codegen-units} -C opt-level=${base.compile.optimization-level} -C debuginfo=${base.compile.debug-level}";
     };
 
     test = {

--- a/test/clippy.bats
+++ b/test/clippy.bats
@@ -5,7 +5,8 @@
 @test "clippy version" {
  result="$( cargo clippy --version )"
  echo $result
- [[ "$result" == *2019-11-14* ]]
+ # [[ nightly ]] || [[ stable ]]
+ [[ "$result" == *2020-02-01* ]] || [[ "$result" == *2020-04-03* ]]
 }
 
 @test "clippy smoke test" {

--- a/test/rust.bats
+++ b/test/rust.bats
@@ -5,7 +5,8 @@
 @test "rustc version" {
  result="$( rustc --version )"
  echo $result
- [[ "$result" == *2019-11-15* ]]
+ # [[ nightly ]] || [[ stable ]]
+ [[ "$result" == *2020-03-09* ]] || [[ "$result" == *2020-04-05* ]]
 }
 
 # the rust fmt version should be roughly the rustc version
@@ -13,12 +14,12 @@
 @test "fmt version" {
  result="$( cargo fmt --version )"
  echo $result
- [[ "$result" == *2019-10-07* ]]
+ [[ "$result" == *2020-01-29* ]] || [[ "$result" == *2020-03-31* ]]
 }
 
 # RUSTFLAGS should be set correctly
 @test "RUSTFLAGS value" {
  result="$( echo $RUSTFLAGS )"
  echo $result
- [[ "$result" == '-D warnings -Z external-macro-backtrace -Z thinlto -C codegen-units=10 -C opt-level=z -C debuginfo=2' ]]
+ [[ "$result" == '-D warnings -C codegen-units=10 -C opt-level=z -C debuginfo=2' ]] || [[ "$result" == '-D warnings -Z external-macro-backtrace -Z thinlto -C codegen-units=10 -C opt-level=z -C debuginfo=2' ]]
 }


### PR DESCRIPTION
This change will ensure we are using rust stable as default, while giving the app developer the possibility to quickly switch to nightly just by changing `rust/config.nix`.