### PR TITLE
rust: introduce use-stable-rust config variable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
 
    # run shell tests
    - run: nix-shell --run hn-test
+   - run: nix-shell --run hn-test --arg use-stable-rust true
 
  debian:
   docker:
@@ -44,6 +45,7 @@ jobs:
        nix-shell --run echo
        ./test/nix-env.sh
        nix-shell --run hn-test
+       nix-shell --run hn-test --arg use-stable-rust true
 
  ubuntu:
   docker:
@@ -57,6 +59,7 @@ jobs:
        nix-shell --run echo
        ./test/nix-env.sh
        nix-shell --run hn-test
+       nix-shell --run hn-test --arg use-stable-rust true
 
  # THIS IS SECURITY SENSITVE
  # READ THESE
@@ -90,6 +93,7 @@ jobs:
        nix-shell --run echo
        ./test/nix-env.sh
        nix-shell --run hn-test
+       nix-shell --run hn-test --arg use-stable-rust true
 
  docker-build-latest:
   resource_class: large

--- a/default.nix
+++ b/default.nix
@@ -5,14 +5,17 @@
 {
  # allow consumers to pass in their own config
  # fallback to empty sets
- config ? import ./config.nix
+ config ? import ./config.nix,
+ use-stable-rust ? false
 }:
 let
  pkgs = import ./nixpkgs;
 
  aws = pkgs.callPackage ./aws { };
  darwin = pkgs.callPackage ./darwin { };
- rust = pkgs.callPackage ./rust { };
+ rust = pkgs.callPackage ./rust {
+  config = config // { holonix.use-stable-rust = use-stable-rust; };
+ };
  node = pkgs.callPackage ./node { };
  git = pkgs.callPackage ./git { };
  linux = pkgs.callPackage ./linux { };

--- a/nix-shell/default.nix
+++ b/nix-shell/default.nix
@@ -27,7 +27,6 @@
  # https://github.com/rust-lang/rustup.rs#environment-variables
  # https://github.com/NixOS/nix/issues/903
  RUSTUP_TOOLCHAIN = rust.channel.version;
- RUSTFLAGS = rust.compile.flags;
  CARGO_INCREMENTAL = rust.compile.incremental;
  RUST_LOG = rust.log;
  NUM_JOBS = rust.compile.jobs;
@@ -59,6 +58,14 @@
    then export NIX_ENV_PREFIX=/home/vagrant
    else export NIX_ENV_PREFIX=`pwd`
   fi
+ fi
+
+ # stable rust doesn't support all the debugging flags we are using
+ if [[ $( rustc --version ) == *nightly ]]
+ then
+  export RUSTFLAGS="${rust.compile.flags}"
+ else
+  export RUSTFLAGS="${rust.compile.stable-flags}"
  fi
 
  export CARGO_HOME="$NIX_ENV_PREFIX/.cargo"

--- a/nix-shell/default.nix
+++ b/nix-shell/default.nix
@@ -61,7 +61,7 @@
  fi
 
  # stable rust doesn't support all the debugging flags we are using
- if [[ $( rustc --version ) == *nightly ]]
+ if [[ $( rustc --version ) == *nightly* ]]
  then
   export RUSTFLAGS="${rust.compile.flags}"
  else

--- a/rust/config.nix
+++ b/rust/config.nix
@@ -81,6 +81,7 @@ let
     compile = base.compile // {
       # @see https://llogiq.github.io/2017/06/01/perf-pitfalls.html
       flags ="-D ${base.compile.deny} -Z external-macro-backtrace -Z ${base.compile.lto} -C codegen-units=${base.compile.codegen-units} -C opt-level=${base.compile.optimization-level} -C debuginfo=${base.compile.debug-level}";
+      stable-flags = "-D ${base.compile.deny} -C codegen-units=${base.compile.codegen-units} -C opt-level=${base.compile.optimization-level} -C debuginfo=${base.compile.debug-level}";
     };
 
     test = {

--- a/rust/default.nix
+++ b/rust/default.nix
@@ -1,4 +1,4 @@
-{ pkgs }:
+{ pkgs, config }:
 let
   rust = import ./config.nix;
 in
@@ -7,7 +7,6 @@ rust //
  buildInputs = []
  # https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/rust.section.md
  ++ [
-  (pkgs.rustChannelOfTargets rust.channel.name rust.channel.date [ rust.wasm-target rust.generic-linux-target  ])
   pkgs.binutils
   pkgs.gcc
   pkgs.gnumake
@@ -17,6 +16,8 @@ rust //
   pkgs.cargo-make
   pkgs.curl
  ]
+ ++ (if (builtins.hasAttr "holonix" config && config.holonix.use-stable-rust) then [ (pkgs.rustChannelOfTargets "stable" null [ rust.wasm-target rust.generic-linux-target  ]) ]
+                                       else [ (pkgs.rustChannelOfTargets rust.channel.name rust.channel.date [ rust.wasm-target rust.generic-linux-target  ]) ])
  ++ (if pkgs.stdenv.isLinux then [ pkgs.kcov ] else [])
  ++ (pkgs.callPackage ./clippy { }).buildInputs
  ++ (pkgs.callPackage ./fmt { }).buildInputs

--- a/test/clippy.bats
+++ b/test/clippy.bats
@@ -5,7 +5,7 @@
 @test "clippy version" {
  result="$( cargo clippy --version )"
  echo $result
- [[ "$result" == *2019-11-14* ]]
+ [[ "$result" == *2019-11-14* || "$result" == *2020-03-17* ]]
 }
 
 @test "clippy smoke test" {

--- a/test/rust.bats
+++ b/test/rust.bats
@@ -5,7 +5,7 @@
 @test "rustc version" {
  result="$( rustc --version )"
  echo $result
- [[ "$result" == *2019-11-15* ]]
+ [[ "$result" == *2019-11-15* || "$result" == *2020-04-20* ]]
 }
 
 # the rust fmt version should be roughly the rustc version
@@ -13,12 +13,12 @@
 @test "fmt version" {
  result="$( cargo fmt --version )"
  echo $result
- [[ "$result" == *2019-10-07* ]]
+ [[ "$result" == *2019-10-07* || "$result" == *2020-03-11* ]]
 }
 
 # RUSTFLAGS should be set correctly
 @test "RUSTFLAGS value" {
  result="$( echo $RUSTFLAGS )"
  echo $result
- [[ "$result" == '-D warnings -Z external-macro-backtrace -Z thinlto -C codegen-units=10 -C opt-level=z -C debuginfo=2' ]]
+ [[ "$result" == '-D warnings -Z external-macro-backtrace -Z thinlto -C codegen-units=10 -C opt-level=z -C debuginfo=2' || "$result" == '-D warnings -C codegen-units=10 -C opt-level=z -C debuginfo=2' ]]
 }


### PR DESCRIPTION
The following gives us possibility to set `use-stable-rust` in subproject _config.nix_ to force usage of stable rust channels.