### PR TITLE
hc-happ-create: specify git ref

### DIFF
--- a/happs/create/default.nix
+++ b/happs/create/default.nix
@@ -4,7 +4,7 @@ let
 
   script = pkgs.writeShellScriptBin name
   ''
-    curl -L -o happ-template.tar.gz https://github.com/holochain/react-graphql-template/archive/master.tar.gz
+    curl -L -o happ-template.tar.gz https://github.com/holochain/react-graphql-template/archive/''${HC_HAPP_CREATE_TEMPLATE_GIT_REF:-master}.tar.gz
     mkdir "''${1:-"Notes-hApp-Template"}"
     tar -zxvf happ-template.tar.gz --strip-components=1 -C ./"''${1:-"Notes-hApp-Template"}"
     rm happ-template.tar.gz

--- a/happs/create/default.nix
+++ b/happs/create/default.nix
@@ -4,7 +4,7 @@ let
 
   script = pkgs.writeShellScriptBin name
   ''
-    curl -L -o happ-template.tar.gz https://github.com/holochain/react-graphql-template/archive/''${HC_HAPP_CREATE_TEMPLATE_GIT_REF:-master}.tar.gz
+    curl -L -o happ-template.tar.gz https://github.com/holochain/react-graphql-template/archive/${HC_HAPP_CREATE_TEMPLATE_GIT_REF:-master}.tar.gz
     mkdir "''${1:-"Notes-hApp-Template"}"
     tar -zxvf happ-template.tar.gz --strip-components=1 -C ./"''${1:-"Notes-hApp-Template"}"
     rm happ-template.tar.gz


### PR DESCRIPTION
It'll help my pre-blessing testing if I can target a specific GitHub ref (e.g., a branch) for the template that `hc-happ-create` downloads. That way, I can bump the dependencies in a staging branch on react-graphql-template, try out `hc-happ-create` in the almost-blessed holonix, and get consistent results.