### PR TITLE
nixpkgs: move to holo-nixpkgs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,28 +96,28 @@ jobs:
        nix-shell --run hn-test --arg use-stable-rust true
 
  docker-build-latest:
-  resource_class: large
+  resource_class: xlarge
   machine: true
   steps:
    - build-docker:
       box: latest
 
  docker-build-ubuntu:
-  resource_class: large
+  resource_class: xlarge
   machine: true
   steps:
    - build-docker:
       box: ubuntu
 
  docker-build-debian:
-  resource_class: large
+  resource_class: xlarge
   machine: true
   steps:
    - build-docker:
       box: debian
 
  docker-build-minimal:
-  resource_class: large
+  resource_class: xlarge
   machine: true
   steps:
    - build-docker:

--- a/nixpkgs/default.nix
+++ b/nixpkgs/default.nix
@@ -1,9 +1,9 @@
 let
   # nixos channel latest 19.09
   # keep the Dockerfile in sync with this!
-  nixpkgs = fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/821c7ed030bca86c8217e6d20df1f01c6474adf4.tar.gz";
-    sha256 = "0varkgzi5nbx4kb6mjmllk1a48pc5nmad6jfikj627yqrb4wcyfw";
+  holo-nixpkgs = fetchTarball {
+    url = "https://github.com/Holo-Host/holo-nixpkgs/archive/7db5779fce5d3a14585ed691b17ffac199c72990.tar.gz";
+    sha256 = "1hanvqp1j0ql01cd0arz3f07nli7a2q2f0p3qdy7w9zr1610zqvk";
   };
 
   # the mozilla rust overlay
@@ -16,6 +16,6 @@ let
   };
 in
 
-import nixpkgs {
+import holo-nixpkgs {
   overlays = [ (import nixpkgs-mozilla) ];
 }

--- a/test/aws.bats
+++ b/test/aws.bats
@@ -3,6 +3,6 @@
 @test "saml2aws version" {
 
  result="$( command -v saml2aws )"
- [[ "$result" == "/nix/store/"*"-saml2aws-2.15.0-bin/bin/saml2aws" ]]
+ [[ "$result" == "/nix/store/"*"-saml2aws-2.19.0/bin/saml2aws" ]]
 
 }

--- a/test/github-release.bats
+++ b/test/github-release.bats
@@ -2,5 +2,5 @@
 
 @test "github-release version" {
  result="$( github-release version )"
- [ "$result" == "1.2.4" ]
+ [ "$result" == "1.2.5" ]
 }

--- a/test/nix-shell.bats
+++ b/test/nix-shell.bats
@@ -7,7 +7,7 @@
 }
 
 @test "watch is installed" {
- [[ $( watch -v ) == "watch from procps-ng 3.3.15" ]]
+ [[ $( watch -v ) == "watch from procps-ng 3.3.16" ]]
  }
 
 @test "rust backtrace is set in shell" {

--- a/test/perf.bats
+++ b/test/perf.bats
@@ -4,5 +4,5 @@
 @test "perf version" {
  result="$( perf --version )"
  echo $result
- [[ "$result" == "perf version 4.19.81" ]]
+ [[ "$result" == "perf version 5.4.36" ]]
 }

--- a/test/rust.bats
+++ b/test/rust.bats
@@ -5,7 +5,7 @@
 @test "rustc version" {
  result="$( rustc --version )"
  echo $result
- [[ "$result" == *2019-11-15* || "$result" == *2020-04-20* ]]
+ [[ "$result" == *2019-11-15* || "$result" == *2020-05-04* ]]
 }
 
 # the rust fmt version should be roughly the rustc version


### PR DESCRIPTION
Making holonix using holo-nixpkgs instead of upstream. This will gives us the benefit of having already build hydra derivations.

As Draft until we upgrade holo-nixpkgs to 20.03.