### PR TITLE
update nix installer commands for 2.3.6 based on new documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
    - run:
       name: Standard tests
       command: |
-       curl https://nixos.org/nix/install | sh
+       sh <(curl -L https://nixos.org/nix/install)
        . /Users/distiller/.nix-profile/etc/profile.d/nix.sh
        nix-shell --run echo
        ./test/nix-env.sh

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -32,7 +32,7 @@ WORKDIR /home/docker
 
 # https://nixos.wiki/wiki/Nix_Installation_Guide#Single-user_install
 RUN sudo install -d -m755 -o $(id -u) -g $(id -g) /nix
-RUN curl https://nixos.org/nix/install | sh
+RUN sh <(curl https://nixos.org/nix/install)
 
 # warm nix and avoid warnings about missing channels
 # https://github.com/NixOS/nixpkgs/issues/40165

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -32,7 +32,7 @@ WORKDIR /home/docker
 
 # https://nixos.wiki/wiki/Nix_Installation_Guide#Single-user_install
 RUN sudo install -d -m755 -o $(id -u) -g $(id -g) /nix
-RUN curl https://nixos.org/nix/install | sh
+RUN sh <(curl https://nixos.org/nix/install)
 
 # warm nix and avoid warnings about missing channels
 # https://github.com/NixOS/nixpkgs/issues/40165

--- a/docs/content/docs/install/index.md
+++ b/docs/content/docs/install/index.md
@@ -34,7 +34,7 @@ apt-get install -y sudo curl
 [Nix installation](https://nixos.org/nix/download.html) is the same on Linux and Mac:
 
 ```bash
-curl https://nixos.org/nix/install | sh
+sh <(curl -L https://nixos.org/nix/install)
 ```
 
 Once installation is finished it will tell you to source the new configuration. Run the command the installer tells you to run.

--- a/docs/public/docs/install/index.html
+++ b/docs/public/docs/install/index.html
@@ -205,7 +205,7 @@ Likely to already be installed on a development machine.</p>
 <h2 id="install-nix-tooling">Install Nix Tooling</h2>
 
 <p><a href="https://nixos.org/nix/download.html">Nix installation</a> is the same on Linux and Mac:</p>
-<div class="highlight"><pre class="chroma"><code class="language-bash" data-lang="bash">curl https://nixos.org/nix/install <span class="p">|</span> sh</code></pre></div>
+<div class="highlight"><pre class="chroma"><code class="language-bash" data-lang="bash">sh &lt;<span class="o">(</span>curl -L https://nixos.org/nix/install<span class="o">)</span></code></pre></div>
 <p>Once installation is finished it will tell you to source the new configuration. Run the command the installer tells you to run.</p>
 
 <p>Once everything is installed and configured the <code>nix-shell</code> should work. Test it out by pulling up the help docs.</p>


### PR DESCRIPTION
This fixes failing CI for `mac`, `docker-build-debian`, and `docker-build-ubuntu`. I hope.