### PR TITLE
[TK-07017] nix-shell: include holochain binaries by default on darwin

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * dna-util: 0.0.1 lair-keystore
 * lair-keystore: 0.0.1-alpha.10
 
-The macOS build is not tested upstream and is currently broken.
+Binaries are available for Darwin and Linux on `x86_64-linux` and `arm64`.
 
 ### Changed
 * perf: 4.19 -> 5.4
@@ -34,4 +34,3 @@ The macOS build is not tested upstream and is currently broken.
 ### Fixed
 
 ### Security
-

--- a/default.nix
+++ b/default.nix
@@ -10,7 +10,7 @@
    url = "https://github.com/Holo-Host/holo-nixpkgs/archive/7663ff8421a6504cd02658b1d5c44c52e307f001.tar.gz";
    sha256 = "0adz6gip6pkx332yh3l7qg47kkgxmfxvdzyfvmkrxq2p3sv2bd6g";
  }) {}
- , includeHolochainBinaries ? (!holo-nixpkgs.stdenv.isDarwin)
+ , includeHolochainBinaries ? true
 }:
 let
  pkgs = import holo-nixpkgs.path {

--- a/default.nix
+++ b/default.nix
@@ -7,8 +7,8 @@
  # fallback to empty sets
  config ? import ./config.nix
  , holo-nixpkgs ? import (fetchTarball {
-   url = "https://github.com/Holo-Host/holo-nixpkgs/archive/b2ce4c5f1a96d11899396a3439e7ed6e6ab4833a.tar.gz";
-   sha256 = "1c8arx55ndlhsgs8g7imm2g0dpzv6576pi7ym8275r3qs03ryyvs";
+   url = "https://github.com/Holo-Host/holo-nixpkgs/archive/7663ff8421a6504cd02658b1d5c44c52e307f001.tar.gz";
+   sha256 = "0adz6gip6pkx332yh3l7qg47kkgxmfxvdzyfvmkrxq2p3sv2bd6g";
  }) {}
  , includeHolochainBinaries ? (!holo-nixpkgs.stdenv.isDarwin)
 }:

--- a/test/default.nix
+++ b/test/default.nix
@@ -4,7 +4,7 @@ let
  # mostly smoke tests on various platforms
  name = "hn-test";
 
- script = pkgs.writeShellScriptBin name (''
+ script = pkgs.writeShellScriptBin name ''
 bats ./test/clippy.bats
 # TODO: revisit when decided on a new gihtub-release binary
 # bats ./test/github-release.bats
@@ -16,9 +16,8 @@ bats ./test/rust.bats
 bats ./test/flamegraph.bats
 # TODO: refactor the happ scaffolding tests for RSM
 # bats ./test/happs.bats
-'' + pkgs.lib.strings.optionalString (!pkgs.stdenv.isDarwin) ''
 bats ./test/holochain-binaries.bats
-'');
+'';
 
 in
 {


### PR DESCRIPTION
- [x] Depends on https://github.com/Holo-Host/holo-nixpkgs/pull/656