### PR TITLE
[TK-07189] holonix: convenient script for using the hydra cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - checkout
 
-      - run: 
+      - run:
           name: Set up Holo's Hydra cache
           command: ./ci/setup-hydra-cache.sh
 
@@ -52,7 +52,7 @@ jobs:
       - image: holochain/holonix:ubuntu
     steps:
       - checkout
-      - run: 
+      - run:
           name: Set up Holo's Hydra cache
           command: ./ci/setup-hydra-cache.sh
       - run:
@@ -87,7 +87,7 @@ jobs:
       NIXPKGS_ALLOW_UNFREE: 1
     steps:
       - checkout
-      - run: 
+      - run:
           name: Set up Holo's Hydra cache
           command: ./ci/setup-hydra-cache.sh
       - run:

--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 {{ version-heading }}
 
 ### Added
+* Convenient script for running the holonix shell. The short-term command will look like this:
+
+    `nix-build https://holochain.love --no-link -A pkgs.holonix`
 
 #### RSM binaries for Linux
 * holochain: 0.0.1

--- a/pkgs/holonix.nix
+++ b/pkgs/holonix.nix
@@ -1,0 +1,63 @@
+{ pkgs }:
+
+let
+  extraSubstitutors = [
+    "https://cache.holo.host"
+  ];
+  trustedPublicKeys = [
+    "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+    "cache.holo.host-1:lNXIXtJgS9Iuw4Cu6X0HINLu9sTfcjEntnrgwMQIMcE="
+    "cache.holo.host-2:ZJCkX3AUYZ8soxTLfTb60g+F3MkWD7hkH9y8CgqwhDQ="
+  ];
+in pkgs.writeScriptBin "holonix" ''
+  export GC_ROOT_DIR="''${HOME:-/tmp}/.holonix"
+  export SHELL_DRV="''${GC_ROOT_DIR}/shellDrv"
+  export LOG="''${GC_ROOT_DIR}/log"
+
+  cat <<- EOF
+  # Holonix
+
+  ## Permissions
+  This scripts uses sudo to allow specifying Holo's Nix binary cache. Specifically:
+  * Instruct Nix to use the following extra substitutors (binary cache):
+    - ${builtins.concatStringsSep "\n- " extraSubstitutors}
+  * Instruct Nix to use trust these public keys:
+    - ${builtins.concatStringsSep "\n  - " trustedPublicKeys}
+
+  ## Caching
+  Holonix will be cached locally.
+  To wipe the cache, remove all symlinks inside ''${GC_ROOT_DIR} and run "nix-collect-garbage".
+
+  ## Running the cached version directly
+  Use: nix-shell ''${SHELL_DRV}
+
+  Building...
+  EOF
+
+  set -eou pipefail
+  mkdir -p "''${GC_ROOT_DIR}"
+  (
+  exec 2>&1
+  nix-instantiate --no-build-output --quiet --add-root "''${SHELL_DRV}" --indirect ${builtins.toString ./.} -A main
+  nix-store \
+      --add-root "''${SHELL_DRV}/refquery" --indirect \
+      --query --references "''${SHELL_DRV}" > "''${GC_ROOT_DIR}/log" | \
+      xargs sudo -E nix-store --realise \
+      --option extra-substituters "${builtins.concatStringsSep " " extraSubstitutors}" \
+      --option trusted-public-keys  "${builtins.concatStringsSep " " trustedPublicKeys}" \
+      --add-root "''${GC_ROOT_DIR}/allrefs" --indirect
+  )  >> "''${LOG}" || {
+  rc=$?
+  echo WARNING: Errors during build. Please see "''${LOG}" for details.
+  if test -e "''${SHELL_DRV}"; then
+      echo Falling back to cached version
+  else
+      exit $rc
+  fi
+  }
+  echo -n Ready!
+  export NIX_BUILD_SHELL=${pkgs.bashInteractive}/bin/bash
+  nix-shell \
+  --add-root "''${GC_ROOT_DIR}/shell" \
+  "''${SHELL_DRV}" ''${@}
+''


### PR DESCRIPTION
It could be used in the following way:

```
$(nix-build . --no-link -A pkgs.holonix)/bin/holonix
```

Any other valid reference to the holonix repository -- including `https`
links -- can be used instead of the `.`.