### PR TITLE
[TK-07189] pkgs/holonix: fix caching bug improve error handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ jobs:
             . /home/docker/.nix-profile/etc/profile.d/nix.sh
             nix-shell --run echo
             nix-shell --run hn-test
+            $(nix-build . --no-link -A pkgs.holonix)/bin/holonix --run hn-test
 
   ubuntu:
     docker:
@@ -60,6 +61,7 @@ jobs:
             . /home/docker/.nix-profile/etc/profile.d/nix.sh
             nix-shell --run echo
             nix-shell --run hn-test
+            $(nix-build . --no-link -A pkgs.holonix)/bin/holonix --run hn-test
 
   # THIS IS SECURITY SENSITVE
   # READ THESE
@@ -102,6 +104,7 @@ jobs:
             # do tests
             nix-shell --run echo
             nix-shell --run hn-test
+            $(nix-build . --no-link -A pkgs.holonix)/bin/holonix --run hn-test
 
   docker-build-latest:
     resource_class: large

--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -1,13 +1,13 @@
 # Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
+l
 {{ version-heading }}
 
 ### Added
-* Convenient script for running the holonix shell. The short-term command will look like this:
+* Convenient script for running the holonix RSM alpha shell. The short-term command will look like this:
 
-    `nix-build https://holochain.love --no-link -A pkgs.holonix`
+    `$(nix-build https://nightly.holochain.love --no-link -A pkgs.holonix)/bin/holonix`
 
 #### RSM binaries for Linux
 * holochain: 0.0.1


### PR DESCRIPTION
Split from #186 

---

holonix
=======
* explicitly set options in subshell to guaranteed catch all piped errors
* don't redirect stdout of nix-store when querying derivation references.
  this redirection was a bug as none of the reference paths were piped
  to the piped `nix-store` invocation.
* only update cached shell on success by using a temporary file as
  derivation path
* cat log on error
* fix argument quoting for the final `nix-shell` invocation
* use `--indirect` consistently for the GC roots

ci
===
* run tests through holonix binary as well

changelog
=========
* adapt the example command to the newly createad `nightly` subdomain