### PR TITLE
pkgs/holonix: reformat, fix error handling, allow sudo opt-out

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
             . /home/docker/.nix-profile/etc/profile.d/nix.sh
             nix-shell --run echo
             nix-shell --run hn-test
-            $(nix-build . --no-link -A pkgs.holonix)/bin/holonix --run hn-test
+            HN_VERBOSE=true $(nix-build . --no-link -A pkgs.holonix)/bin/holonix --run hn-test
 
   ubuntu:
     docker:
@@ -61,7 +61,7 @@ jobs:
             . /home/docker/.nix-profile/etc/profile.d/nix.sh
             nix-shell --run echo
             nix-shell --run hn-test
-            $(nix-build . --no-link -A pkgs.holonix)/bin/holonix --run hn-test
+            HN_VERBOSE=true $(nix-build . --no-link -A pkgs.holonix)/bin/holonix --run hn-test
 
   # THIS IS SECURITY SENSITVE
   # READ THESE
@@ -104,7 +104,7 @@ jobs:
             # do tests
             nix-shell --run echo
             nix-shell --run hn-test
-            $(nix-build . --no-link -A pkgs.holonix)/bin/holonix --run hn-test
+            HN_VERBOSE=true $(nix-build . --no-link -A pkgs.holonix)/bin/holonix --run hn-test
 
   docker-build-latest:
     resource_class: large

--- a/default.nix
+++ b/default.nix
@@ -17,7 +17,7 @@ let
   overlays = holo-nixpkgs.overlays
     ++ [
       (self: super: {
-        holonix = self.callPackage ./pkgs/holonix.nix { };
+        holonix = ((import <nixpkgs> {}).callPackage or self.callPackage) ./pkgs/holonix.nix { };
       })
     ]
     ;

--- a/pkgs/holonix.nix
+++ b/pkgs/holonix.nix
@@ -9,6 +9,15 @@ let
     "cache.holo.host-1:lNXIXtJgS9Iuw4Cu6X0HINLu9sTfcjEntnrgwMQIMcE="
     "cache.holo.host-2:ZJCkX3AUYZ8soxTLfTb60g+F3MkWD7hkH9y8CgqwhDQ="
   ];
+
+  buildCmd = ''
+      $(command -v nix-store) \
+          --option extra-substituters "${builtins.concatStringsSep " " extraSubstitutors}" \
+          --option trusted-public-keys  "${builtins.concatStringsSep " " trustedPublicKeys}" \
+          --add-root "''${GC_ROOT_DIR}/allrefs" --indirect \
+          --realise "''${ref}"
+  '';
+
 in pkgs.writeShellScriptBin "holonix" ''
   export GC_ROOT_DIR="''${HOME:-/tmp}/.holonix"
   export SHELL_DRV="''${GC_ROOT_DIR}/shellDrv"
@@ -20,9 +29,11 @@ in pkgs.writeShellScriptBin "holonix" ''
   ## Permissions
   This scripts uses sudo to allow specifying Holo's Nix binary cache. Specifically:
   * Instruct Nix to use the following extra substitutors (binary cache):
-    - ${builtins.concatStringsSep "\n- " extraSubstitutors}
+    - ${builtins.concatStringsSep "\n - " extraSubstitutors}
   * Instruct Nix to use trust these public keys:
     - ${builtins.concatStringsSep "\n  - " trustedPublicKeys}
+
+  If you don't want to use "sudo", you can set HN_NOSUDO="true" prior to calling this script.
 
   ## Caching
   Holonix will be cached locally.
@@ -34,38 +45,66 @@ in pkgs.writeShellScriptBin "holonix" ''
   Building...
   EOF
 
-  set -Eeou pipefail
-  mkdir -p "''${GC_ROOT_DIR}"
-  (
-  exec 2>&1
-  set -Eeou pipefail
-  SHELL_DRV_TMP=$(mktemp)
-  rm ''${SHELL_DRV_TMP}
-
-  nix-instantiate --no-build-output --quiet --add-root "''${SHELL_DRV_TMP}" --indirect ${builtins.toString ./.}/.. -A main
-  nix-store \
-      --add-root "''${GC_ROOT_DIR}/refquery" --indirect \
-      --query --references "''${SHELL_DRV_TMP}" | \
-      xargs sudo -E nix-store --realise \
-      --option extra-substituters "${builtins.concatStringsSep " " extraSubstitutors}" \
-      --option trusted-public-keys  "${builtins.concatStringsSep " " trustedPublicKeys}" \
-      --add-root "''${GC_ROOT_DIR}/allrefs" --indirect
-  mv ''${SHELL_DRV_TMP} ''${SHELL_DRV}
-  )  >> "''${LOG}" || {
-  rc=$?
-  echo -n "Errors during build. "
-  if [[ -e ''${SHELL_DRV} ]]; then
-      echo Please see "''${LOG}" for details.
-      echo Falling back to cached version
-  else
-      cat "''${LOG}"
-      exit $rc
+  if [[ $(uname) == "Darwin" ]]; then
+    echo macOS detected, disabling sudo.
+    export HN_NOSUDO="true"
   fi
-  }
 
-  echo -n Ready!
+  set -euo pipefail
+  mkdir -p "''${GC_ROOT_DIR}"
+
+  function handle_error() {
+    rc=$?
+
+    echo "Errors during build. Status: $rc)"
+    if [[ -e ''${SHELL_DRV} ]]; then
+        echo Please see "''${LOG}" for details.
+        echo Falling back to cached version
+    else
+        cat ''${LOG}
+        exit $rc
+    fi
+  }
+  trap handle_error err
+
+  function handle_int() {
+    rc=$?
+    if [[ ''${HN_VERBOSE:-false} != "true" ]]; then
+      echo Check ''${LOG} for the build output.
+    fi
+    echo Aborting.
+    exit $rc
+  }
+  trap handle_int int
+
+  (
+    if [[ ''${HN_VERBOSE:-false} != "true" ]]; then
+      exec 2>''${LOG} 1>>''${LOG}
+    fi
+
+    SHELL_DRV_TMP=$(mktemp)
+    rm ''${SHELL_DRV_TMP}
+
+    nix-instantiate --add-root "''${SHELL_DRV_TMP}" --indirect ${builtins.toString ./.}/.. -A main
+    for ref in `nix-store \
+                --add-root "''${GC_ROOT_DIR}/refquery" --indirect \
+                --query --references "''${SHELL_DRV_TMP}"`;
+    do
+      echo Processing ''${ref}
+
+      if [[ "''${HN_NOSUDO:-false}" == "true" ]]; then
+        ${buildCmd}
+      else
+        sudo -E ${buildCmd}
+      fi
+    done
+
+    mv -f ''${SHELL_DRV_TMP} ''${SHELL_DRV}
+  )
+
+  echo Spawning shell..
   export NIX_BUILD_SHELL=${pkgs.bashInteractive}/bin/bash
   nix-shell \
-  --add-root "''${GC_ROOT_DIR}/finalShell" --indirect \
-  "''${SHELL_DRV}" "''${@}"
+    --add-root "''${GC_ROOT_DIR}/finalShell" --indirect \
+    "''${SHELL_DRV}" "''${@}"
 ''


### PR DESCRIPTION
* The main motivation for this change is to fix the error handling for the
  subshell that builds the shell dependencies. Every build error should
  cause an immediate abortion of the build process, and in case of no
  cached shell derivation, should immediately quit the script.

  The bug that prevented this was caused by the syntax:

  ```shell
  ( build code ) || { error handling code }
  ```

  Which did not have the desired effect. Instead of this construct, the
  code is now using a trap for SIGERR which works reliably.

* Evaluate the full-path to `nix-store` and pass that to `sudo`.
* Disable `sudo` on macOS because because it breaks `nix-store`.
* Print build output on CI.
* Force overwrite of the shellDrv link.