### PR TITLE
ci: consistently use holo's hydra cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,9 @@ jobs:
             - "52:70:20:1e:fe:e3:1c:74:cc:b9:5e:b4:04:30:03:e6"
       - checkout
       - run:
+          name: Set up Holo's Hydra cache
+          command: ./ci/setup-hydra-cache.sh
+      - run:
           name: Deploy github pages
           command: |
             git config user.name "$GITHUB_PAGES_DEPLOY_USER"

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -34,6 +34,9 @@ WORKDIR /home/docker
 RUN sudo install -d -m755 -o $(id -u) -g $(id -g) /nix
 RUN curl -L https://nixos.org/nix/install | sh
 
+# Set up Holo's Hydra cache
+RUN ./ci/setup-hydra-cache.sh
+
 # warm nix and avoid warnings about missing channels
 # https://github.com/NixOS/nixpkgs/issues/40165
 RUN . /home/docker/.nix-profile/etc/profile.d/nix.sh; nix-channel --update; nix-shell https://holochain.love --run echo;

--- a/docker/Dockerfile.latest
+++ b/docker/Dockerfile.latest
@@ -8,6 +8,9 @@ ENV USER root
 # keep this matching nix-shell!
 ENV NIX_PATH nixpkgs=channel:nixos-19.09
 
+# Set up Holo's Hydra cache
+RUN ./ci/setup-hydra-cache.sh
+
 # run a no-op to warm the nix store
 RUN nix-shell https://holochain.love --run "echo 1" --show-trace
 

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -34,6 +34,9 @@ WORKDIR /home/docker
 RUN sudo install -d -m755 -o $(id -u) -g $(id -g) /nix
 RUN curl -L https://nixos.org/nix/install | sh
 
+# Set up Holo's Hydra cache
+RUN ./ci/setup-hydra-cache.sh
+
 # warm nix and avoid warnings about missing channels
 # https://github.com/NixOS/nixpkgs/issues/40165
 RUN . /home/docker/.nix-profile/etc/profile.d/nix.sh; nix-channel --update; nix-shell https://holochain.love --run echo;


### PR DESCRIPTION
This will save significant effort for the CI runs on master and love.

Fixes #195 