### PR TITLE
nix-shell: add cacert dependency

### DIFF
--- a/git/default.nix
+++ b/git/default.nix
@@ -4,6 +4,7 @@
  [
   pkgs.git
   pkgs.gitAndTools.git-hub
+  pkgs.cacert
   # need the haskellPackages version for darwin support
   # broken
   # pkgs.haskellPackages.github-release


### PR DESCRIPTION
This seems to be necessary on non-NixOS hosts to enable the cloning of git repositories with cargo.