### PR TITLE
Merge develop to master

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -8,6 +8,7 @@ l
 * Convenient script for running the holonix RSM alpha shell. The short-term command will look like this:
 
     `$(nix-build https://nightly.holochain.love --no-link -A pkgs.holonix)/bin/holonix`
+* `hn-introspect` script to list which holochain packages were pulled in for the nix-shell
 
 #### RSM binaries for Linux
 * holochain: 0.0.1
@@ -16,6 +17,31 @@ l
 * kitsune-p2p-proxy: 0.0.1
 
 Binaries are available for Darwin and Linux on `x86_64-linux` and `arm64`.
+
+#### Configurable holochain/holo-nixpkgs versions
+* Add a section for holo-nixpkgs to config.nix
+* Introduce arguments for choosing the included holochain binaries:
+  * holochainVersionId: can be one of "hpos", "main", "develop", or "custom" as of now.
+  * holochainVersion: if `holochainVersionId` is "custom", this specifies a set with holochain source information. Example:
+    ```nix
+      version = "2021-02-05";
+      rev = "fd8049a48ac12ef3e190b48a79ffe8d8b5948caa";
+      sha256 = "065kkmmr8b5ngjqpr7amd7l4dcakj2njx168qvr5z47mmqs9xbgw";
+      cargoSha256 = "1ix8ihlizjsmx8xaaxknbl0wkyck3kc98spipx5alav8ln4wf46s";
+    ```
+
+    Altogether the invocation could look like:
+    ```console
+        nix-shell . --argstr holochainVersionId "custom" --arg holochainVersion '{
+          version = "custom";
+          rev = "fd8049a48ac12ef3e190b48a79ffe8d8b5948caa";
+          sha256 = "065kkmmr8b5ngjqpr7amd7l4dcakj2njx168qvr5z47mmqs9xbgw";
+          cargoSha256 = "1ix8ihlizjsmx8xaaxknbl0wkyck3kc98spipx5alav8ln4wf46s";
+        }'
+    ```
+  * holochainOtherDepsNames: list of package names to include in the shell. Names are keys to `holo-nixpkgs`. Example that is also the default: `[ "lair-keystore" ]`
+
+
 
 ### Changed
 * perf: 4.19 -> 5.4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,0 @@
-[package]
-name = "holonix_fake_crate"
-version = "0.0.1"
-description = "a fake crate used to test commands"
-license = "GPL-3.0-only"

--- a/config.nix
+++ b/config.nix
@@ -29,4 +29,44 @@ echo "<your publishing script here>"
    '';
   };
  };
+
+ holo-nixpkgs = rec {
+  use-github = true;
+
+  github = rec {
+   # can be any github ref
+   # branch, tag, commit, etc.
+   ref = "b03baa20d49f6b94769f68318d8b94a0c5bf95b4";
+
+   # the sha of what is downloaded from the above ref
+   # note: even if you change the above ref it will not be redownloaded until
+   #       the sha here changes (the sha is the cache key for downloads)
+   # note: to get a new sha, get nix to try and download a bad sha
+   #       it will complain and tell you the right sha
+   sha256 = "0q5f98swng1n28w7ah3q8kjpdzzardvzmgq0qsli173kg2ii6hqd";
+
+   # the github owner of the holonix repo
+   owner = "Holo-Host";
+
+   # the name of the holonix repo
+   repo = "holo-nixpkgs";
+
+  };
+
+  # configuration for when use-github = false
+  local = {
+   # the path to the local holonix copy
+   path = ../holo-nixpkgs;
+  };
+
+  importFn = _: import (
+     if use-github
+     then builtins.fetchTarball (with github; {
+        url = "https://github.com/${owner}/${repo}/archive/${ref}.tar.gz";
+        inherit sha256; }
+       )
+     else local.path
+    ) {}
+    ;
+ };
 }

--- a/default.nix
+++ b/default.nix
@@ -6,24 +6,46 @@
  # allow consumers to pass in their own config
  # fallback to empty sets
  config ? import ./config.nix
- , holo-nixpkgs ? import (fetchTarball {
-   url = "https://github.com/Holo-Host/holo-nixpkgs/archive/7663ff8421a6504cd02658b1d5c44c52e307f001.tar.gz";
-   sha256 = "0adz6gip6pkx332yh3l7qg47kkgxmfxvdzyfvmkrxq2p3sv2bd6g";
- }) {}
+ , holo-nixpkgs ? config.holo-nixpkgs.importFn {}
  , includeHolochainBinaries ? true
+
+ # either of: hpos, develop, main, custom. when "custom" is set, `holochainVersion` needs to be specified
+ , holochainVersionId? "develop"
+ , holochainVersion ? (if holochainVersionId == "custom"
+                       then null
+                       else builtins.getAttr holochainVersionId holo-nixpkgs.holochainVersions
+                      )
+ , holochainOtherDepsNames ? [ "lair-keystore" ]
 }:
+
+assert (holochainVersionId == "custom") -> holochainVersion != null;
+
 let
  pkgs = import holo-nixpkgs.path {
   overlays = holo-nixpkgs.overlays
     ++ [
       (self: super: {
         holonix = ((import <nixpkgs> {}).callPackage or self.callPackage) ./pkgs/holonix.nix { };
+        holonixIntrospect = self.callPackage ./pkgs/holonix-introspect.nix { pkgsOfInterest = self.holochainBinaries; };
 
         # these are referenced in holochain-s merge script.
         # ideally we'd expose all packages in this repository in this way.
         hnRustClippy = builtins.elemAt (self.callPackage ./rust/clippy {}).buildInputs 0;
         hnRustFmtCheck = builtins.elemAt (self.callPackage ./rust/fmt/check {}).buildInputs 0;
         hnRustFmtFmt = builtins.elemAt (self.callPackage ./rust/fmt/fmt {}).buildInputs 0;
+        inherit holochainVersionId;
+        holochainBinaries =
+          if !includeHolochainBinaries then {} else
+          if holochainVersionId == "custom" then
+            holo-nixpkgs.mkHolochainAllBinariesWithDeps (holochainVersion // {
+              otherDeps =
+                builtins.map (name: builtins.getAttr name holo-nixpkgs)
+                  holochainOtherDepsNames
+                  ;
+            })
+          else
+            (builtins.getAttr holochainVersionId holo-nixpkgs.holochainAllBinariesWithDeps)
+          ;
       })
     ]
     ;
@@ -65,17 +87,9 @@ let
     happs
     ;
   extraBuildInputs = [
+      pkgs.holonixIntrospect
     ]
-    ++ (
-      if includeHolochainBinaries
-      then with pkgs; [
-        holochain
-        dna-util
-        lair-keystore
-        kitsune-p2p-proxy
-      ]
-      else []
-      )
+    ++ (builtins.attrValues pkgs.holochainBinaries)
     ;
  };
 

--- a/pkgs/holonix-introspect.nix
+++ b/pkgs/holonix-introspect.nix
@@ -1,0 +1,20 @@
+{ lib
+, pkgs
+, writeShellScriptBin
+, holochainVersionId
+, pkgsOfInterest
+}:
+
+let
+  namesVersionsString = lib.attrsets.mapAttrsToList (name: value:
+    if builtins.isAttrs value && builtins.hasAttr "src" value
+    then "echo \- ${name}: " + (builtins.toString value.src.urls)
+    else ""
+  ) pkgsOfInterest;
+
+in
+writeShellScriptBin "hn-introspect" ''
+  echo holochainVersionId: ${holochainVersionId}
+  echo List of holochain packages and their upstream information:
+  ${builtins.concatStringsSep "\n" namesVersionsString}
+''

--- a/test/clippy.bats
+++ b/test/clippy.bats
@@ -9,10 +9,6 @@
 }
 
 @test "clippy smoke test" {
- hn-rust-clippy
- hn-rust-fmt-check
- hn-rust-fmt-fmt
-
  # the clippy target directory should have been created
  clippy_target_dir="$CARGO_TARGET_DIR/clippy"
  [[ "$clippy_target_dir" == "$PWD"/target/clippy ]]

--- a/test/holochain-binaries.bats
+++ b/test/holochain-binaries.bats
@@ -3,7 +3,7 @@
 @test "expected holochain version available" {
   result="$(holochain --version)"
   echo $result
-  [[ "$result" == *" 0.0.1" ]]
+  [[ "$result" == *" 0.0.100" ]]
 }
 
 @test "expected dna-util version available" {

--- a/test/nix-shell.bats
+++ b/test/nix-shell.bats
@@ -14,3 +14,8 @@
  [ "$RELEASE_VERSION" == "_._._" ]
  [ "$RELEASE_TAG" == "v_._._" ]
 }
+
+@test "hn-introspect lists holochain" {
+ hn-introspect | egrep '.*- holochain: https://github.com/holochain/holochain/archive/.*.tar.gz.*'
+
+}


### PR DESCRIPTION
This merges in recent changes for specifying the `holoVersionId`, which ultimately chooses which holochain binaries to install.