### PR TITLE
nix-shell: allow overriding the rust version

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -25,8 +25,11 @@ Binaries are available for Darwin and Linux on `x86_64-linux` and `arm64`.
   * holochainVersionId: can be one of "hpos", "main", "develop", or "custom" as of now.
   * holochainVersion: if `holochainVersionId` is "custom", this specifies a set with holochain source information.
   * include: a set that controls which components to include in the shell
+  * rustVersion: allows overriding the nix-shell's rust version. examples:
+      * using a specific nightly version: '{ track = "nightly"; version = "2021-07-01"; }'
+      * using a specific stable version: '{ track = "stable"; version = "1.53.0"; }'
 
-    Please see the files in _examples/_ for a usage examples.
+  Please see the files in _examples/_ for more usage examples.
 
 ### Changed
 * perf: 4.19 -> 5.4

--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -22,7 +22,7 @@ Binaries are available for Darwin and Linux on `x86_64-linux` and `arm64`.
 * Add a section for holochain-nixpkgs to config.nix
 * Introduce arguments for choosing the included holochain binaries:
 
-  * holochainVersionId: can be one of "hpos", "main", "develop", or "custom" as of now.
+  * holochainVersionId: can be one of "main", "develop", or "custom" as of now.
   * holochainVersion: if `holochainVersionId` is "custom", this specifies a set with holochain source information.
   * include: a set that controls which components to include in the shell
   * rustVersion: allows overriding the nix-shell's rust version. examples:

--- a/default.nix
+++ b/default.nix
@@ -18,7 +18,17 @@
                       )
   # DEPRECRATED: this is no longer used
  , holochainOtherDepsNames ? [ ]
+
+ , rustVersion ? {}
+ , rustc ? (if rustVersion == {}
+            then holochain-nixpkgs.pkgs.rust.packages.stable.rust.rustc
+            else holochain-nixpkgs.pkgs.rust.mkRust ({
+              track = "stable";
+              version = "1.54.0";
+            } // (if rustVersion != null then rustVersion else {}))
+           )
 }:
+
 
 assert (holochainVersionId == "custom") -> holochainVersion != null;
 
@@ -52,7 +62,7 @@ let
 
  components = {
   rust = pkgs.callPackage ./rust {
-     inherit config;
+     inherit config rustc;
   };
   node = pkgs.callPackage ./node { };
   git = pkgs.callPackage ./git { };

--- a/nix-shell/default.nix
+++ b/nix-shell/default.nix
@@ -13,7 +13,7 @@
  happs
 , extraBuildInputs
 }:
-pkgs.mkShell {
+(pkgs.mkShell {
  name = "holonix-shell";
 
  # non-nixos OS can have a "dirty" setup with rustup installed for the current
@@ -91,4 +91,6 @@ pkgs.mkShell {
  ;
 
  inputsFrom = builtins.attrValues pkgs.holochainBinaries;
-}
+}).overrideAttrs(attrs: {
+  nativeBuildInputs = builtins.filter (el: (builtins.match ".*(rust|cargo).*" el.name) == null) attrs.nativeBuildInputs;
+})

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "holochain-nixpkgs": {
-        "branch": "pr/rust-version-selection",
+        "branch": "develop",
         "description": null,
         "homepage": null,
         "owner": "holochain",
         "repo": "holochain-nixpkgs",
-        "rev": "fa846e309438a7f982412eb2b3e72110d3da6332",
+        "rev": "9184278c53cab799d86678438e19503c8ebd74f3",
         "sha256": "0n9hvjzmzvs07255rap99ijf3zv9vmnxaimsrbnclqci52dbvhwa",
         "type": "tarball",
-        "url": "https://github.com/holochain/holochain-nixpkgs/archive/fa846e309438a7f982412eb2b3e72110d3da6332.tar.gz",
+        "url": "https://github.com/holochain/holochain-nixpkgs/archive/9184278c53cab799d86678438e19503c8ebd74f3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "holochain-nixpkgs": {
-        "branch": "develop",
+        "branch": "pr/rust-version-selection",
         "description": null,
         "homepage": null,
         "owner": "holochain",
         "repo": "holochain-nixpkgs",
-        "rev": "d0f3b630accce342c8cb0f2d2a6b62c4c830b7b3",
-        "sha256": "16shl1nz2wymf4bp2055qi75j4lim517nikczgzbm2j9x00ilkf3",
+        "rev": "fa846e309438a7f982412eb2b3e72110d3da6332",
+        "sha256": "0n9hvjzmzvs07255rap99ijf3zv9vmnxaimsrbnclqci52dbvhwa",
         "type": "tarball",
-        "url": "https://github.com/holochain/holochain-nixpkgs/archive/d0f3b630accce342c8cb0f2d2a6b62c4c830b7b3.tar.gz",
+        "url": "https://github.com/holochain/holochain-nixpkgs/archive/fa846e309438a7f982412eb2b3e72110d3da6332.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {

--- a/rust/default.nix
+++ b/rust/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, config }:
+{ pkgs, config, rustc ? pkgs.rust.packages.stable.rust.rustc }:
 let
   rust = import ./config.nix;
 in
@@ -14,7 +14,7 @@ rust //
   pkgs.pkgconfig
   pkgs.cargo-make
   pkgs.curl
-  pkgs.rust.packages.stable.rust.rustc
+  rustc
  ]
  ++ (if pkgs.stdenv.isLinux then [ pkgs.kcov ] else [])
  ++ (pkgs.callPackage ./clippy { }).buildInputs


### PR DESCRIPTION
This introduces the option of specifying a rust track and version.  By
default the shell exposes the default stable rust from
holochain-nixpkgs.