### PR TITLE
update holochain-nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "holochain",
         "repo": "holochain-nixpkgs",
-        "rev": "3c1e1c2916c0938c59faf806a99820ab80399ce1",
-        "sha256": "1fzff033wjlcsxim12yrg1b8r81zmkx6zf14xk33lmjzwlwv7r68",
+        "rev": "0a619754f9608990a42fad3e0372be8ecad7b936",
+        "sha256": "0mqif2n2z6amcjlipgg4lrbj48vh4qpavlahsjsfsz38y0j9kgg5",
         "type": "tarball",
-        "url": "https://github.com/holochain/holochain-nixpkgs/archive/3c1e1c2916c0938c59faf806a99820ab80399ce1.tar.gz",
+        "url": "https://github.com/holochain/holochain-nixpkgs/archive/0a619754f9608990a42fad3e0372be8ecad7b936.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
---
the following versions are now available via their respective holochainVersionId:

holochainVersionId: main
- hc-0.0.14: https://github.com/holochain/holochain/archive/14ee16ecf0bd20c215b0f238e853f6762b113c51.tar.gz
- holochain-0.0.113: https://github.com/holochain/holochain/archive/14ee16ecf0bd20c215b0f238e853f6762b113c51.tar.gz
- kitsune-p2p-proxy-0.0.10: https://github.com/holochain/holochain/archive/14ee16ecf0bd20c215b0f238e853f6762b113c51.tar.gz
- lair-keystore-0.0.8: https://github.com/holochain/lair/archive/v0.0.8.tar.gz

holochainVersionId: develop
- hc-0.0.10: https://github.com/holochain/holochain/archive/a411e9dbe0f4a580b8cb44d5b5d7d8dc3d013ac3.tar.gz
- holochain-0.0.109: https://github.com/holochain/holochain/archive/a411e9dbe0f4a580b8cb44d5b5d7d8dc3d013ac3.tar.gz
- kitsune-p2p-proxy-0.0.8: https://github.com/holochain/holochain/archive/a411e9dbe0f4a580b8cb44d5b5d7d8dc3d013ac3.tar.gz
- lair-keystore-0.0.7: https://github.com/holochain/lair/archive/v0.0.7.tar.gz

---
as well as the following common commands of interest:

- rustc: rustc 1.55.0 (c8dfcfe04 2021-09-06)
- cargo fmt: rustfmt 1.4.37-stable (c8dfcfe 2021-09-06)
- cargo clippy: clippy 0.1.55 (c8dfcfe 2021-09-06)
- perf: perf version 5.10.67