### PR TITLE
update holochain-nixpkgs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
             # fix for "too many open files" that breaks tokio and lmdb
             ulimit -n 10240
             # catalina nixos install
-            sh <(curl -L https://nixos.org/nix/install) --darwin-use-unencrypted-nix-store-volume
+            sh <(curl -L https://releases.nixos.org/nix/nix-2.3.8/install) --darwin-use-unencrypted-nix-store-volume
       - nix-prepare-test-push
 
   docker-build-ubuntu:

--- a/ci/cachix.sh
+++ b/ci/cachix.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i bash -p bash -p cachix -I nixpkgs="channel:nixos-21.05"
+#! nix-shell -i bash -p "((import ./config.nix).holochain-nixpkgs.importFn {}).pkgs.cachix"
 
-# nix-shell -i bash -p "((import ./config.nix).holochain-nixpkgs.importFn {}).pkgs.cachix"
+#  nix-shell -i bash -p bash -p cachix -I nixpkgs="channel:nixos-21.05"
 
 set -euo pipefail
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "holochain",
         "repo": "holochain-nixpkgs",
-        "rev": "0a619754f9608990a42fad3e0372be8ecad7b936",
-        "sha256": "0mqif2n2z6amcjlipgg4lrbj48vh4qpavlahsjsfsz38y0j9kgg5",
+        "rev": "d868e47b7e12a8866bfc6f5602a638706609799b",
+        "sha256": "1rcxg7kxjzbkpb5xpj49mqmdzxcm6rz0wcs5zhv4vbad5acbk8c5",
         "type": "tarball",
-        "url": "https://github.com/holochain/holochain-nixpkgs/archive/0a619754f9608990a42fad3e0372be8ecad7b936.tar.gz",
+        "url": "https://github.com/holochain/holochain-nixpkgs/archive/d868e47b7e12a8866bfc6f5602a638706609799b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
---
the following versions are now available via their respective holochainVersionId:

holochainVersionId: main
- hc-0.0.15: https://github.com/holochain/holochain/archive/43e5a2ca5a7bf59a7b1beff1f54a13af1bf7ac52.tar.gz
- holochain-0.0.114: https://github.com/holochain/holochain/archive/43e5a2ca5a7bf59a7b1beff1f54a13af1bf7ac52.tar.gz
- kitsune-p2p-proxy-0.0.11: https://github.com/holochain/holochain/archive/43e5a2ca5a7bf59a7b1beff1f54a13af1bf7ac52.tar.gz
- lair-keystore-0.0.8: https://github.com/holochain/lair/archive/v0.0.8.tar.gz

holochainVersionId: develop
- hc-0.0.10: https://github.com/holochain/holochain/archive/a411e9dbe0f4a580b8cb44d5b5d7d8dc3d013ac3.tar.gz
- holochain-0.0.109: https://github.com/holochain/holochain/archive/a411e9dbe0f4a580b8cb44d5b5d7d8dc3d013ac3.tar.gz
- kitsune-p2p-proxy-0.0.8: https://github.com/holochain/holochain/archive/a411e9dbe0f4a580b8cb44d5b5d7d8dc3d013ac3.tar.gz
- lair-keystore-0.0.7: https://github.com/holochain/lair/archive/v0.0.7.tar.gz

---
as well as the following common commands of interest:

- rustc: rustc 1.55.0 (c8dfcfe04 2021-09-06)
- cargo fmt: rustfmt 1.4.37-stable (c8dfcfe 2021-09-06)
- cargo clippy: clippy 0.1.55 (c8dfcfe 2021-09-06)
- perf: perf version 5.10.67