### PR TITLE
update holochain-nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "holochain",
         "repo": "holochain-nixpkgs",
-        "rev": "d868e47b7e12a8866bfc6f5602a638706609799b",
-        "sha256": "1rcxg7kxjzbkpb5xpj49mqmdzxcm6rz0wcs5zhv4vbad5acbk8c5",
+        "rev": "a7c344947dd6aca9f7a262eb2ad708e6eca14367",
+        "sha256": "0kijy7qygjq6sirjwnia8irl62bi95ghxfq1f8gh6pywwz1kkc23",
         "type": "tarball",
-        "url": "https://github.com/holochain/holochain-nixpkgs/archive/d868e47b7e12a8866bfc6f5602a638706609799b.tar.gz",
+        "url": "https://github.com/holochain/holochain-nixpkgs/archive/a7c344947dd6aca9f7a262eb2ad708e6eca14367.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
---
the following versions are now available via their respective holochainVersionId:

holochainVersionId: main
- hc-0.0.16: https://github.com/holochain/holochain/archive/efd47955adbf381bf9a886b0e0f9146dfd6be46c.tar.gz
- holochain-0.0.115: https://github.com/holochain/holochain/archive/efd47955adbf381bf9a886b0e0f9146dfd6be46c.tar.gz
- kitsune-p2p-proxy-0.0.12: https://github.com/holochain/holochain/archive/efd47955adbf381bf9a886b0e0f9146dfd6be46c.tar.gz
- lair-keystore-0.0.9: https://github.com/holochain/lair/archive/v0.0.9.tar.gz

holochainVersionId: develop
- hc-0.0.10: https://github.com/holochain/holochain/archive/a411e9dbe0f4a580b8cb44d5b5d7d8dc3d013ac3.tar.gz
- holochain-0.0.109: https://github.com/holochain/holochain/archive/a411e9dbe0f4a580b8cb44d5b5d7d8dc3d013ac3.tar.gz
- kitsune-p2p-proxy-0.0.8: https://github.com/holochain/holochain/archive/a411e9dbe0f4a580b8cb44d5b5d7d8dc3d013ac3.tar.gz
- lair-keystore-0.0.7: https://github.com/holochain/lair/archive/v0.0.7.tar.gz

---
as well as the following common commands of interest:

- rustc: rustc 1.55.0 (c8dfcfe04 2021-09-06)
- cargo fmt: rustfmt 1.4.37-stable (c8dfcfe 2021-09-06)
- cargo clippy: clippy 0.1.55 (c8dfcfe 2021-09-06)
- perf: perf version 5.10.67