### PR TITLE
{regen_versions,update}: reduce side-effects and use nixUnstable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,11 +32,20 @@ commands:
             # TODO: decide whether or not we want to keep this
             # HN_VERBOSE=true $(nix-build . --no-link -A pkgs.holonix)/bin/holonix --run hn-test
       - run:
+          name: run the update script
+          command: |
+            . $HOME/.nix-profile/etc/profile.d/nix.sh
+            nix-shell -p git --run '
+              git config --global user.email "ci@holochain.org"
+              git config --global user.name "Holochain CI"
+              ./nix/update.sh
+              PAGER="" git show
+            '
+      - run:
           name: push to cachix
           command: |
             . $HOME/.nix-profile/etc/profile.d/nix.sh
             ./ci/cachix.sh push
-
 jobs:
   build:
     docker:

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -6,7 +6,7 @@ The following binaries are the same version regardless of the _holochainVersionI
 - rustc: rustc 1.55.0 (c8dfcfe04 2021-09-06)
 - cargo fmt: rustfmt 1.4.37-stable (c8dfcfe 2021-09-06)
 - cargo clippy: clippy 0.1.55 (c8dfcfe 2021-09-06)
-- perf: perf version 5.10.87
+- perf: mirror://kernel/linux/kernel/v5.x/linux-5.10.87.tar.xz
 
 ## Available _holochainVersionId_ options
 Each of the following headings represent one pre-built _holochainVersionId_ and their corresponding holochain version information.

--- a/nix/regen_versions.sh
+++ b/nix/regen_versions.sh
@@ -1,11 +1,15 @@
 #! /usr/bin/env nix-shell
+#! nix-shell --pure --keep NIX_PATH
+#! nix-shell -p nixUnstable
 #! nix-shell -p niv -p yq -i bash
 
 set -e
 
+export NIX_CONFIG="extra-experimental-features = nix-command";
+
 # read the ids from holochain-nixpkg's CI configuration
 # all of these are verified to build and cached
-yq_input="$(nix eval --raw '(builtins.toString (import nix/sources.nix).holochain-nixpkgs)')/.github/workflows/build.yml"
+yq_input="$(nix eval --impure --raw --expr '(builtins.toString (import nix/sources.nix).holochain-nixpkgs)')/.github/workflows/build.yml"
 ids="$(yq -r <${yq_input} '.jobs."holochain-binaries".strategy.matrix.nixAttribute | join(" ")')"
 
 cat << EOF > VERSIONS.md

--- a/nix/regen_versions.sh
+++ b/nix/regen_versions.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env nix-shell
 #! nix-shell --pure --keep NIX_PATH
-#! nix-shell -p nixUnstable
+#! nix-shell -p cacert nixUnstable
 #! nix-shell -p niv -p yq -i bash
 
 set -e

--- a/nix/update.sh
+++ b/nix/update.sh
@@ -1,4 +1,6 @@
 #! /usr/bin/env nix-shell
+#! nix-shell --pure --keep NIX_PATH
+#! nix-shell -p cacert -p nixUnstable -p git
 #! nix-shell -p niv -i bash
 niv update
 


### PR DESCRIPTION
this still isn't as pure as i'd like it to as it reuses NIX_PATH. ideally we could make use of the sources we have in `nix/sources.nix` but i wasn't able to figure this out with the `#! /usr/bin/env nix-shell` approach.