### PR TITLE
add hn-versions command

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -89,6 +89,8 @@ let
           inherit (self) holochainBinaries;
         };
 
+        holonixVersions = self.callPackage ./pkgs/holonix-versions.nix { };
+
         # these are referenced in holochain-s merge script.
         # ideally we'd expose all packages in this repository in this way.
         hnRustClippy = builtins.elemAt (self.callPackage ./rust/clippy {}).buildInputs 0;
@@ -150,6 +152,7 @@ let
     ;
   extraBuildInputs = [
       pkgs.holonixIntrospect
+      pkgs.holonixVersions
     ]
     ++ (if !includeHolochainBinaries then [] else
       (builtins.attrValues pkgs.holochainBinaries)

--- a/pkgs/holonix-versions.nix
+++ b/pkgs/holonix-versions.nix
@@ -1,0 +1,6 @@
+{ writeShellScriptBin
+}:
+
+writeShellScriptBin "hn-versions" ''
+  cat ${../VERSIONS.md}
+''


### PR DESCRIPTION
this command serves as a stop-gap until we have a more intuitive version discovery utility.