### PR TITLE
github-actions: explicitly set exit code in catch-all job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,6 +41,9 @@ jobs:
   ci-jobs-succeed:
     needs: [tests]
     runs-on: ubuntu-latest
+    if: always()
     steps:
-      - name: echo
-        run: echo
+      - name: Check status
+        env:
+          RESULTS: "${{ toJSON(needs.*.result) }}"
+        run: "[[ $(jq -n 'env.RESULTS | fromjson | unique == [\"success\"]') == \"true\" ]]\n"

--- a/.github/workflows/update-dispatch.yml
+++ b/.github/workflows/update-dispatch.yml
@@ -57,4 +57,9 @@ jobs:
   all-jobs-succeed:
     runs-on: "ubuntu-latest"
     needs: [call-update]
-    steps: [{ name: "all-jobs-succeed", run: ":" }]
+    if: always()
+    steps:
+      - name: Check status
+        env:
+          RESULTS: "${{ toJSON(needs.*.result) }}"
+        run: "[[ $(jq -n 'env.RESULTS | fromjson | unique == [\"success\"]') == \"true\" ]]\n"

--- a/nix/update.sh
+++ b/nix/update.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env nix-shell
 #! nix-shell ../default.nix
 #! nix-shell --pure
-#! nix-shell --arg include '{ node = false; scaffolding = false; rust = false; }'
+#! nix-shell --arg include "{ node = false; scaffolding = false; rust = false; }"
 #! nix-shell --keep GITHUB_TOKEN
 #! nix-shell -i bash
 


### PR DESCRIPTION
this is an unfortuante workaround that seems necessary by a bug on
github actions. the bug shows itself under the following conditions

1. github branch protection is set up to require a status check for a job that 'needs' other jobs
2. auto-merge is enabled a PR
3. the workflow run gets cancelled
4. BUG: the PR gets merged despite the required status check being
   'cancelled'