### PR TITLE
fix(nix-shell): always include holochain's dependencies

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -130,6 +130,9 @@ let
     happs = pkgs.callPackage ./happs { };
     introspection = { buildInputs = [ pkgs.holonixIntrospect ]; };
     holochainBinaries = { buildInputs = (builtins.attrValues pkgs.holochainBinaries); };
+    holochainDependencies = pkgs.mkShell {
+      inputsFrom = (builtins.attrValues pkgs.holochainBinaries);
+    };
     scaffolding = pkgs.callPackage ./scaffolding { inherit sources; };
   };
 


### PR DESCRIPTION
this is required to be able to build holochain even when the binaries
are not included.