### PR TITLE
feat(nix-shell): extract niv into a separate component

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -137,6 +137,7 @@ let
       inputsFrom = (builtins.attrValues pkgs.holochainBinaries);
     };
     scaffolding = pkgs.callPackage ./scaffolding { inherit sources; };
+    niv = { buildInputs = [ pkgs.niv ]; };
   };
 
   componentsFiltered =

--- a/nix-shell/default.nix
+++ b/nix-shell/default.nix
@@ -4,7 +4,6 @@
 , coreutils
 , flamegraph
 , nixUnstable
-, niv
 
 , holochain-nixpkgs
 , holonixComponents
@@ -46,7 +45,6 @@ let
 
     buildInputs = [
       nixUnstable
-      niv
 
       # for mktemp
       coreutils


### PR DESCRIPTION
this allows Apple Silicon users to exclude niv and potentially have
a working holonix. it's still considered unsupported as of now.