### PR TITLE
on 'main' it should remain 'main'

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -14,7 +14,7 @@
   }
 
   # either one listed in VERSIONS.md or "custom". when "custom" is set, `holochainVersion` needs to be specified
-, holochainVersionId ? "develop"
+, holochainVersionId ? "main"
 , holochainVersion ? null
 , rustVersion ? { }
 , rustc ? (if rustVersion == { }


### PR DESCRIPTION
This reverts commit cf796369e677b5688a19e26387c1b51b197d7095.

on 'main' it should remain 'main'