### PR TITLE
refactor(default.nix): only include rust, holochain and niv

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,8 +9,20 @@
 , holochain-nixpkgs ? config.holochain-nixpkgs.importFn { }
 , includeHolochainBinaries ? include.holochainBinaries or true
 , include ? {
+    holochainBinaries = true;
+    rust = true;
+    niv = true;
     test = false;
     scaffolding = false;
+    node = false;
+    git = false;
+    linux = false;
+    docs = false;
+    openssl = false;
+    release = false;
+    happs = false;
+    introspection = false;
+    holochainDependencies = false;
   }
 
   # either one listed in VERSIONS.md or "custom". when "custom" is set, `holochainVersion` needs to be specified


### PR DESCRIPTION
Reduce `default.nix` includes to only keep Rust, Holochain & Lair and niv

I've just tested this successfully on an aarch64-darwin machine. Note there's still the `NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1` flag required, but that must be due to our own declaration. There's no issue from the current nixpgks.

I suggest we get rid of this flag before merging this.