### PR TITLE
workaround(github/pr): ignore build derivation errors on macos

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         platform:
           - ubuntu-latest
-          - macos-latest
+          # - macos-latest
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout repository


### PR DESCRIPTION
this is currently broken and we prefer to keep CI automated