### PR TITLE
feat(default): make holochainVersionId 'main' an alias for the highest version

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -12,10 +12,12 @@ The following binaries are the same version regardless of the _holochainVersionI
 Each of the following headings represent one pre-built _holochainVersionId_ and their corresponding holochain version information.
 
 ### main
-- hc-0.1.0-beta-rc.1: https://github.com/holochain/holochain/tree/eb1e637c353190bfdba8b742c6b8bbb1b3f4a669
-- holochain-0.1.0-beta-rc.1: https://github.com/holochain/holochain/tree/eb1e637c353190bfdba8b742c6b8bbb1b3f4a669
-- kitsune-p2p-tx2-proxy-0.1.0-beta-rc.0: https://github.com/holochain/holochain/tree/eb1e637c353190bfdba8b742c6b8bbb1b3f4a669
+- hc-0.1.0-beta-rc.2: https://github.com/holochain/holochain/tree/holochain-0.1.0-beta-rc.2
+- holochain-0.1.0-beta-rc.2: https://github.com/holochain/holochain/tree/holochain-0.1.0-beta-rc.2
+- kitsune-p2p-tx2-proxy-0.1.0-beta-rc.0: https://github.com/holochain/holochain/tree/holochain-0.1.0-beta-rc.2
 - lair-keystore-0.2.3: https://github.com/holochain/lair/tree/lair_keystore_api-v0.2.3
+- launcher-0.0.3-alpha.2: https://github.com/holochain/launcher/tree/holochain_cli_launch-0.0.3-alpha.2
+- scaffolding-0.0.5: https://github.com/holochain/scaffolding/tree/holochain_scaffolding_cli-v0.0.5-alpha.0
 
 ### develop
 - hc-0.1.0-beta-rc.1: https://github.com/holochain/holochain/tree/ca75e980f926c72d1d082239c8a7252a71254421

--- a/default.nix
+++ b/default.nix
@@ -34,6 +34,17 @@ let
       if holochainVersion == null
       then throw ''When 'holochainVersionId' is set to "custom" a value to 'holochainVersion' must be provided.''
       else holochainVersion
+    else if holochainVersionId == "main"
+    then
+      # make "main" the equivalent of the highest known version
+      # we introduce this behavior because we currently don't have hc-{scaffold,launch} for branch names
+      # makes use of the natural sorting of attribute sets
+
+      let
+        values = builtins.attrValues holochain-nixpkgs.packages.holochain.holochainVersions;
+        lastIndex = (builtins.length values)-1;
+      in
+        builtins.elemAt values lastIndex
     else
       (
         let


### PR DESCRIPTION
make "main" the equivalent of the highest known version
we introduce this behavior because we currently don't have hc-{scaffold,launch} for branch names
